### PR TITLE
feat: snowAccumulationHeight

### DIFF
--- a/existence_smp_handler/data/existence_smp/functions/setup/setup.mcfunction
+++ b/existence_smp_handler/data/existence_smp/functions/setup/setup.mcfunction
@@ -3,6 +3,7 @@ gamerule disableElytraMovementCheck true
 gamerule playersSleepingPercentage 25
 gamerule spawnRadius 175
 gamerule spectatorsGenerateChunks true
+gamerule snowAccumulationHeight 8
 
 function existence_smp:setup/teams
 function existence_smp:setup/scoreboards


### PR DESCRIPTION
Adds 
```mcfunction
gamerule snowAccumulationHeight 8
```
 to `existence_smp:setup/setup`, allowing for falling snow to form a full block (of layers)